### PR TITLE
fix album links

### DIFF
--- a/hud-data/candyhud.json
+++ b/hud-data/candyhud.json
@@ -2,7 +2,7 @@
   "name": "candyhud",
   "author": "quickkennedy",
   "social": {
-    "album": "https://imgur.com/a/HbWUrVL"
+    "album": "https://imgur.com/a/5ks1D88"
   },
   "repo": "https://github.com/quickkennedy/candyhud",
   "hash": "c5fd838416babb76634527478fcae4e296d64115",

--- a/hud-data/cutehud.json
+++ b/hud-data/cutehud.json
@@ -2,7 +2,7 @@
   "name": "cutehud",
   "author": "quickkennedy",
   "social": {
-    "album": "https://imgur.com/a/QrGEQo7"
+    "album": "https://imgur.com/a/kaAQlTJ"
   },
   "repo": "https://github.com/quickkennedy/cutehud",
   "hash": "1d7603ad29f55a34602f08d796764514c49ad42a",


### PR DESCRIPTION
cutehud update fixes the oddly shared album between zehud and cutehud
candyhud update links to the (although identical in contents) proper album that i uploaded a while back, so if i make any changes in the future i can update the screenshots