### PR TITLE
bump budhud hash

### DIFF
--- a/hud-data/budhud.json
+++ b/hud-data/budhud.json
@@ -61,7 +61,7 @@
   },
   "tags": ["minimal"],
   "repo": "https://github.com/rbjaxter/budhud",
-  "hash": "9fb7728b1bbe7febf835a7831bff437134f7ff97",
+  "hash": "4e9b93e299f28fb2c0f3d39cfad2deaae7f1d9d4",
   "resources": [
     "budhud-01-banner",
     "budhud-02-backpack",


### PR DESCRIPTION
Did you ever hear the tragedy of Budhud the Wise? It is a tale not told in the annals of the Force, but in the realms of Team Fortress 2. Budhud was a powerful and customizable heads-up display, known for its ability to manipulate the very essence of the game interface. Dark, sleek, and filled with an insidious efficiency, it allowed its users to control and foresee the battlefield like no other. Its customization was so profound that it could influence not only the visual aesthetics but also the tactical awareness of those who wielded its power. Yet, as the legend goes, with great customization came great temptation. The Budhud, in its dark glory, could lead its users down a path of obsession, altering their perception of the game itself. In the end, the alluring power of Budhud proved too intoxicating, and many a player found themselves lost in its depths, forever bound to its digital embrace.