### PR TITLE
HUD update: m0re-techno middlemann technohud

### DIFF
--- a/hud-data/m0re-techno.json
+++ b/hud-data/m0re-techno.json
@@ -53,7 +53,7 @@
     ]
   },
   "repo": "https://github.com/tekunotri/m0re_techno",
-  "hash": "2a55c48e7c06a350bf229afb829741fecfac43e7",
+  "hash": "c8b1c78c0be972b922584d9b631ba9863c6f6242",
   "parent": "m0rehud",
   "resources": [
     "m0re-techno-banner",

--- a/hud-data/middlemann.json
+++ b/hud-data/middlemann.json
@@ -69,7 +69,7 @@
     "vanilla"
   ],
   "repo": "https://github.com/Vexcenot/-Middle-Mann",
-  "hash": "720b500bdb6a59b8c480ed6bc37e9519ec4c9ea5",
+  "hash": "d5bc167b51e4c1d4defede36405c24c87bcbc30c",
   "resources": [
     "middlemann-banner"
   ]

--- a/hud-data/technohud.json
+++ b/hud-data/technohud.json
@@ -47,7 +47,7 @@
     "monochrome"
   ],
   "repo": "https://github.com/tekunotri/technohud",
-  "hash": "502697bcdd1925ef1e5b76ae488114ed5f89bd86",
+  "hash": "343cf3857e2fc34de2e21879d69c86885c448f87",
   "prerelease": true,
   "resources": [
     "th-banner",

--- a/hud-data/technohud.json
+++ b/hud-data/technohud.json
@@ -47,7 +47,7 @@
     "monochrome"
   ],
   "repo": "https://github.com/tekunotri/technohud",
-  "hash": "343cf3857e2fc34de2e21879d69c86885c448f87",
+  "hash": "a12cc8a9677ede6c5962648db0d482eb34d051e9",
   "prerelease": true,
   "resources": [
     "th-banner",


### PR DESCRIPTION
technohud 0.37A/B:
- made ammo/hp/uber a bit bigger
- some enhancements to match hud
- new round counter design
- removed `MainBG` as it isn't needed anymore
- adjusted hudinspectpanel sizing a bit
- overheal plus is now green
- made roundcounter smaller + redesigned points for mp_winlimit
- changed map location on spectator hud
- lowered font size on killfeed

m0re_techno
- like 1 font

middlemann:
- some bugfixes