### PR TITLE
Delete hud-resources/toucahud/desktop.ini

### DIFF
--- a/hud-resources/toucahud/desktop.ini
+++ b/hud-resources/toucahud/desktop.ini
@@ -1,9 +1,0 @@
-[LocalizedFileNames]
-toucahud-ingametauntmenu.jpg=@toucahud-ingametauntmenu,0
-toucahud-ingameheadcount.jpg=@toucahud-ingameheadcount,0
-toucahud-ingamestickycount.jpg=@toucahud-ingamestickycount,0
-toucahud-ingamedisguise.jpg=@toucahud-ingamedisguise,0
-toucahud-stats.jpg=@toucahud-stats,0
-toucahud-loadouts.jpg=@toucahud-loadouts,0
-toucahud-backpack.jpg=@toucahud-backpack,0
-toucahud-backpackwithmetal.jpg=@toucahud-backpackwithmetal,0


### PR DESCRIPTION
This file is not needed for HUD purposes. It's an automatically-generated file and it's only applicable for the Windows OS. It may be hidden by default for Windows users because it's considered a system-protected file.

For instance, when you extract files with WinRAR or 7-Zip, if there are any `desktop.ini`/`Thumbs.db` etc. misc. files they will be automatically ignored by default (will not be extracted).