### PR TITLE
Update spacehud.json

### DIFF
--- a/hud-data/spacehud.json
+++ b/hud-data/spacehud.json
@@ -16,7 +16,7 @@
     "customization"
   ],
   "traits": {
-    "os": ["windows", "linux"],
+    "os": ["windows", "mac", "linux"],
     "gamemode": [
       "tournament",
       "comp",
@@ -39,9 +39,9 @@
     "res": ["4/3", "5/4", "16/9", "16/10"],
     "lang": ["en"]
   },
-  "tags": ["minimalist", "simple"],
+  "tags": ["minimalist", "simple", "blue"],
   "repo": "https://github.com/BingBongBonky/SpaceHud",
-  "hash": "8e41f97d65515ba94c8b70c434c866d23607c721",
+  "hash": "caf2d37dc78242bfe4c827b401a9f178aaa285c2",
   "resources": [
     "spacehud-01-mainpage",
     "spacehud-02-menu",


### PR DESCRIPTION
[Changelog here](https://github.com/BingBongBonky/SpaceHUD/releases/tag/1.6.0)

### Gamemode Selection Panel
* Fixed the No Connection icons or disabled icons from overlapping with the game mode text
* Fixed return or close arrows not being lined up and being cut off
### Main Menu
* Fixed no game coordinator connection message being cut off
    * Changed color to a deeper red
* Fixed longer names having the trailing ... cut off in the friends panel
* Added a drop shadow to the SpaceHUD label
* Made match search pop-up cover the entire SpaceHUD label
* Made match found pop-up not cover the  SpaceHUD label
* Cleaned up the previous two pop-ups
* Cleaned up the MOTD
### In-game
* Fixed chat history being cut off when not typing
* Scoreboard should allow longer names to show up properly
* Fixed team labels on scoreboard not being centered vertically