### PR TITLE
idhud: sync latest README changes

### DIFF
--- a/hud-data/improved-default-hud.json
+++ b/hud-data/improved-default-hud.json
@@ -40,7 +40,7 @@
   "tags": ["default", "improved", "idhud", "vanilla", "minimal"],
   "repo": "https://github.com/idhud-tf2/idhud",
   "githubAuthor": "Eniere",
-  "hash": "8c9f2f31fcfc733b56850526322bb38979ed3680",
+  "hash": "67f864b6487363e49eee4d4507763ca473c90f61",
   "prerelease": false,
   "resources": [
   "1-idhud_banner",


### PR DESCRIPTION
Only two commits:

first https://github.com/idhud-tf2/idhud/commit/7338d71f3c768dcb2a28df5c5ad6687c4201e17b

second https://github.com/idhud-tf2/idhud/commit/67f864b6487363e49eee4d4507763ca473c90f61